### PR TITLE
Readme should say Ubuntu under installation-notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ OBS: The client machine needs to have a X11 server installed (Xpra). See the "No
 
 ##Docker Installation
 
-###On Linux:
+###On Ubuntu:
 Docker is available as a Ubuntu PPA (Personal Package Archive), hosted on launchpad which makes installing Docker on Ubuntu very easy.
 
 ```


### PR DESCRIPTION
... since linux has a plethora of package-managers and naming-conventions
