### PR TITLE
apt-get update and apt-get upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ FROM ubuntu:14.04
 MAINTAINER Roberto G. Hashioka "roberto_hashioka@hotmail.com"
 
 RUN apt-get update -y
+RUN apt-get upgrade -y
 
 # Set the env variable DEBIAN_FRONTEND to noninteractive
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
-y flag is required for apt-get update otherwise, it does not actually update packages.
apt-get upgrade -y is needed to update existing packages for security updates.
