### PR TITLE
Fixes readme for GitHub rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DOCKER-DESKTOP
 ==============
 
-##Description
+## Description
 
 This Dockerfile creates a docker image and once it's executed it creates a container that runs X11 and SSH services.
 The ssh is used to forward X11 and provide you encrypted data communication between the docker container and your local machine.
@@ -17,9 +17,9 @@ Fluxbox and ROX-Filer creates a very minimalist way to manages the windows and f
 
 OBS: The client machine needs to have a X11 server installed (Xpra). See the "Notes" below. 
 
-##Docker Installation
+## Docker Installation
 
-###On Ubuntu:
+### On Ubuntu:
 Docker is available as a Ubuntu PPA (Personal Package Archive), hosted on launchpad which makes installing Docker on Ubuntu very easy.
 
 ```
@@ -32,18 +32,18 @@ sudo apt-get update
 # Install, you will see another warning that the package cannot be authenticated. Confirm install.
 sudo apt-get install lxc-docker
 ```
-###On Windows:
+### On Windows:
 Requirements:
 - Installation Tutorial (http://docs.docker.io/en/latest/installation/windows/)
 
-###On Mac OS X:
+### On Mac OS X:
 Requirements:
 - Installation Tutorial (http://docs.docker.io/en/latest/installation/vagrant/)
 
-##Installation
+## Installation
 
 
-###Building the docker image
+### Building the docker image
 
 ```
 $ docker build -t rogaha/docker-desktop git://github.com/rogaha/docker-desktop.git
@@ -55,13 +55,13 @@ $ cd docker-desktop
 $ docker build -t [username]/docker-desktop .
 ```
 
-###Running the docker image created (-d: detached mode, -P: expose the port 22 on the host machine)
+### Running the docker image created (-d: detached mode, -P: expose the port 22 on the host machine)
 
 ```
 $ CONTAINER_ID=$(docker run -d -P [username]/docker-desktop)
 ```
 
-###Getting the password generated during runtime
+### Getting the password generated during runtime
 
 ```
 $ echo $(docker logs $CONTAINER_ID | sed -n 1p)
@@ -69,18 +69,18 @@ User: docker Password: xxxxxxxxxxxx
 # where xxxxxxxxxxxx is the password created by PWGen that contains at least one capital letter and one number
 ```
 
-##Usage
+## Usage
 
-###Getting the container's external ssh port 
+### Getting the container's external ssh port 
 
 ```
 $ docker port $CONTAINER_ID 22
 49153 # This is the external port that forwards to the ssh service running inside of the container as port 22
 ```
 
-###Connecting to the container 
+### Connecting to the container 
 
-####Starting the a new session 
+#### Starting the a new session 
 
 ```
 $ ifconfig | grep "inet addr:" 
@@ -99,7 +99,7 @@ Usage: docker-desktop [-s screen_size] [-d session_number]
 -----------------------------------------------------------
 ```
 
-####Attaching to the session started
+#### Attaching to the session started
 
 ```
 $ xpra --ssh="ssh -p 49153" attach ssh:docker@192.168.56.102:10 # user@ip_address:session_number
@@ -111,20 +111,20 @@ DISPLAY=:[session_number] [program_name] &
 
 Eg. DISPLAY=:10 firefox &
 
-##Notes
+## Notes
 
-###On Windows:
+### On Windows:
 Requirements:
 - Xpra <= 14.0 (https://www.xpra.org/dists/windows/)
 - Path: C:\Program Files(x86)\Xpra\Xpra_cmd.exe
 
-###On OS X:
+### On OS X:
 Requirements:
 - Xpra Version <= 14.0 (https://www.xpra.org/dists/osx/x86/)
 - Path: /Applications/Xpra.app/Contents/Helpers/xpra
 
 
-###On Linux:
+### On Linux:
 Requirements:
 - Xpra: You can use apt-get to install it -> apt-get install xpra
 - Path: /usr/bin/xpra


### PR DESCRIPTION
The readme is currently very difficult to find sections in as the titles are being rendered as paragraphs, not headings. This PR fixes the markdown syntax so heading are rendered correctly. 