### PR TITLE
Update to Ubuntu 16.04 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get upgrade -y
 ENV DEBIAN_FRONTEND noninteractive
 
 # Installing the environment required: xserver, xdm, flux box, roc-filer and ssh
-RUN apt-get install -y xpra rox-filer openssh-server pwgen xserver-xephyr xdm fluxbox xvfb sudo
+RUN apt-get install -y xpra rox-filer openssh-server pwgen xserver-xephyr xdm fluxbox xvfb locales sudo
 
 # Configuring xdm to allow connections from any IP address and ssh to allow X11 Forwarding. 
 RUN sed -i 's/DisplayManager.requestPort/!DisplayManager.requestPort/g' /etc/X11/xdm/xdm-config

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Date: 07/28/2013
 
 
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Roberto G. Hashioka "roberto_hashioka@hotmail.com"
 
 RUN apt-get update -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN apt-get install -y xpra rox-filer openssh-server pwgen xserver-xephyr xdm fl
 # Configuring xdm to allow connections from any IP address and ssh to allow X11 Forwarding. 
 RUN sed -i 's/DisplayManager.requestPort/!DisplayManager.requestPort/g' /etc/X11/xdm/xdm-config
 RUN sed -i '/#any host/c\*' /etc/X11/xdm/Xaccess
-RUN ln -s /usr/bin/Xorg /usr/bin/X
 RUN echo X11Forwarding yes >> /etc/ssh/ssh_config
 
 # Fix PAM login issue with sshd


### PR DESCRIPTION
Updated the Dockerfile so that it pulls an Ubuntu 16.04 base image and solved a couple of issues with RUN directives, namely:

- X is symlinked to Xorg by default now, so line 35 made the docker build fail;
- the UTF-8 locales your build is looking for is now part of a separate package, so I've included it among the base packages which are installed first and foremost.

Forwarding looks good from my side, so let me know!